### PR TITLE
Keep LEDs on, flush LL mode updates

### DIFF
--- a/src/main/java/frc/robot/commands/ShootCommand.java
+++ b/src/main/java/frc/robot/commands/ShootCommand.java
@@ -13,7 +13,7 @@ import frc.robot.subsystems.LimelightSubsystem;
 import frc.robot.subsystems.ShooterSubsystem;
 
 /**
- * ShootCommand
+ * Aims at the target and shoots once.
  */
 public class ShootCommand extends CommandBase {
 
@@ -49,12 +49,12 @@ public class ShootCommand extends CommandBase {
     noTarget = false;
     shot = false;
     pidController.reset();
+    highLimelightSubsystem.enable();
+    lowLimelightSubsystem.enable();
   }
 
   @Override
   public void execute() {
-    highLimelightSubsystem.enable();
-    lowLimelightSubsystem.enable();
     if (highLimelightSubsystem.getTargetAcquired()) {
       shooterSubsystem.prepareToShoot(Units.metersToInches(highLimelightSubsystem.getDistanceToTarget()));
       aimShooter(highLimelightSubsystem);
@@ -91,8 +91,6 @@ public class ShootCommand extends CommandBase {
     shooterSubsystem.stopShooter();
     indexerSubsystem.stopIndexer();
     driveTrainSubsystem.stop();
-    highLimelightSubsystem.disable();
-    lowLimelightSubsystem.disable();
   }
 
 }

--- a/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
@@ -58,9 +58,17 @@ public class LimelightSubsystem extends SubsystemBase {
     targetX = table.getEntry("tx").getDouble(0.0);
     targetY = table.getEntry("ty").getDouble(0.0);
 
+    // Flush NetworkTable to send LED mode and pipeline updates immediately
+    var shouldFlush = (table.getEntry("ledMode").getDouble(0.0) != (enabled ? 0.0 : 1.0) || 
+        limelightNetworkTable.getEntry("pipeline").getDouble(0.0) != activeProfile.pipelineId);
+    
     table.getEntry("ledMode").setDouble(enabled ? 0.0 : 1.0);
     table.getEntry("camMode").setDouble(enabled ? 0.0 : 1.0);
     limelightNetworkTable.getEntry("pipeline").setDouble(activeProfile.pipelineId);
+
+    if (shouldFlush)  {
+      NetworkTableInstance.getDefault().flush();
+    }
   }
 
   public boolean getTargetAcquired() {


### PR DESCRIPTION
This should speed up acquiring targets during a match:

- Keep the LL LEDs on for the whole match.
- Flush the NetworkTable when we change the LED mode or the pipeline. This should send the data immediately instead of waiting up to a second for the next update cycle.