### PR TITLE
Feedforward drivetrain

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -92,7 +92,7 @@ public final class Constants {
     public static final double SLOW_MODE_SPEED_MULTIPLIER = .6;
     public static final double SLOW_MODE_ROTATION_MULTIPLIER = .9;
 
-    public static final double DEADBAND_HIGH = 0.09;
+    public static final double DEADBAND_HIGH = 0.11;
     public static final double DEADBAND_LOW = -DEADBAND_HIGH;
   }
 
@@ -104,7 +104,7 @@ public final class Constants {
     public static final double MAX_ANGULAR_VEL_ARCADE = Units.degreesToRadians(360);
 
     // Max rate of change for speed per second
-    public static final double SPEED_RATE_LIMIT_ARCADE = 1.5;
+    public static final double SPEED_RATE_LIMIT_ARCADE = 2.5;
 
     // Max rate of change for rotation per second
     public static final double ROTATE_RATE_LIMIT_ARCADE = 3.0;

--- a/src/main/java/frc/robot/commands/PixyAssistCommand.java
+++ b/src/main/java/frc/robot/commands/PixyAssistCommand.java
@@ -12,8 +12,8 @@ public class PixyAssistCommand extends CommandBase{
   private final DriveTrainSubsystem driveTrainSubsystem;
 
   private PixyVisionVariables pixyData;
-  private static final int lower = 92; 
-  private static final int upper = 162;
+  private static final int lower = 102; 
+  private static final int upper = 152;
   private static final double speed = 0.6;
 
   public PixyAssistCommand(DriveTrainSubsystem driveTrainSubsystem, PixyVisionSubsystem pixy) {
@@ -48,13 +48,13 @@ public class PixyAssistCommand extends CommandBase{
       SmartDashboard.putNumber("Object Area", pixyData.area);
     }else if(lower>pixyData.xCoord){
       //object is to the left of the bot
-      driveTrainSubsystem.tankDrive((speed/3), speed, false);//turn left until object is within the safe zone
+      driveTrainSubsystem.tankDrive((speed/5), speed, false);//turn left until object is within the safe zone
       pixyData = pixy.getCoordinates();
       SmartDashboard.putString("Pixy Command", "Left");
       SmartDashboard.putNumber("Object Area", pixyData.  area);
     }else if(pixyData.xCoord>upper){
       //object is to the right of the bot
-      driveTrainSubsystem.tankDrive(speed, (speed/3), false);//turn right until object is within the safe zone
+      driveTrainSubsystem.tankDrive(speed, (speed/5), false);//turn right until object is within the safe zone
       pixyData = pixy.getCoordinates();
       SmartDashboard.putString("Pixy Command", "Right");
       SmartDashboard.putNumber("Object Area", pixyData.area);

--- a/src/main/java/frc/robot/commands/ShootCommand.java
+++ b/src/main/java/frc/robot/commands/ShootCommand.java
@@ -62,7 +62,7 @@ public class ShootCommand extends CommandBase {
         indexerSubsystem.shoot();
         shot = true;
       } else {
-        indexerSubsystem.stopIndexer();
+        indexerSubsystem.prepareToShoot();
       }
     } else {
       noTarget = true;

--- a/src/main/java/frc/robot/commands/ShootCommand.java
+++ b/src/main/java/frc/robot/commands/ShootCommand.java
@@ -41,7 +41,7 @@ public class ShootCommand extends CommandBase {
     addRequirements(shooterSubsystem, indexerSubsystem, highLimelightSubsystem, lowLimelightSubsystem,
         driveTrainSubsystem);
 
-    pidController.setTolerance(.03);
+    pidController.setTolerance(.1);
   }
 
   @Override
@@ -62,7 +62,7 @@ public class ShootCommand extends CommandBase {
         indexerSubsystem.shoot();
         shot = true;
       } else {
-        indexerSubsystem.prepareToShoot();
+        indexerSubsystem.stopIndexer();
       }
     } else {
       noTarget = true;

--- a/src/main/java/frc/robot/subsystems/DriveTrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrainSubsystem.java
@@ -125,7 +125,7 @@ public class DriveTrainSubsystem extends SubsystemBase {
   private void handleEncoderEntry(EntryNotification notification) {
     var entry = notification.getEntry();
     if(entry.getBoolean(true) && (!encodersAvailable || !useEncoders)) {
-      useEncoders = false; // TODO allow turning on encoder drive
+      useEncoders = true;
       enableEncoders();
     } else if (!entry.getBoolean(true)) {
       useEncoders = false;

--- a/src/main/java/frc/robot/subsystems/DriveTrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveTrainSubsystem.java
@@ -31,7 +31,6 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.SPI;
 import edu.wpi.first.wpilibj.SlewRateLimiter;
 import edu.wpi.first.wpilibj.controller.RamseteController;
-import edu.wpi.first.wpilibj.drive.DifferentialDrive;
 import edu.wpi.first.wpilibj.geometry.Pose2d;
 import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.kinematics.ChassisSpeeds;
@@ -59,8 +58,6 @@ public class DriveTrainSubsystem extends SubsystemBase {
   private final WPI_TalonSRX rightMaster = new WPI_TalonSRX(DEVICE_ID_RIGHT_MASTER);
   private final WPI_VictorSPX rightSlaveOne = new WPI_VictorSPX(DEVICE_ID_RIGHT_SLAVE_ONE);
   private final WPI_VictorSPX rightSlaveTwo = new WPI_VictorSPX(DEVICE_ID_RIGHT_SLAVE_TWO);
-
-  private final DifferentialDrive differentialDrive = new DifferentialDrive(leftMaster, rightMaster);
 
   private final AHRS gyro = new AHRS(SPI.Port.kMXP);
   private final DifferentialDriveOdometry differentialDriveOdometry;
@@ -109,8 +106,6 @@ public class DriveTrainSubsystem extends SubsystemBase {
     leftSlaveTwo.follow(leftMaster);
     rightSlaveOne.follow(rightMaster);
     rightSlaveTwo.follow(rightMaster);
-
-    differentialDrive.setRightSideInverted(false);
   }
 
   public void addDashboardWidgets(ShuffleboardLayout dashboard) {
@@ -186,21 +181,22 @@ public class DriveTrainSubsystem extends SubsystemBase {
    * @param useSquares if set, decreases input sensitivity at low speeds
    */
   public void arcadeDrive(double speed, double rotation, boolean useSquares) {
+    var xSpeed = speed;
+    var zRotation = rotation;
+    if (useSquares) {
+      xSpeed *= Math.abs(xSpeed);
+      zRotation *= Math.abs(zRotation);
+    }
+    xSpeed = speedRateLimiter.calculate(safeClamp(speed));
+    zRotation = -rotationRateLimiter.calculate(safeClamp(rotation));
+    xSpeed *= MAX_SPEED_ARCADE;
+    zRotation *= MAX_ANGULAR_VEL_ARCADE;
+    var wheelSpeeds = DRIVE_KINEMATICS.toWheelSpeeds(new ChassisSpeeds(xSpeed, 0.0, zRotation));
     if(useEncoders) {
-      var xSpeed = speed;
-      var zRotation = rotation;
-      if (useSquares) {
-        xSpeed *= Math.abs(xSpeed);
-        zRotation *= Math.abs(zRotation);
-      }
-      xSpeed = speedRateLimiter.calculate(safeClamp(speed));
-      zRotation = -rotationRateLimiter.calculate(safeClamp(rotation));
-      xSpeed *= MAX_SPEED_ARCADE;
-      zRotation *= MAX_ANGULAR_VEL_ARCADE;
-      var wheelSpeeds = DRIVE_KINEMATICS.toWheelSpeeds(new ChassisSpeeds(xSpeed, 0.0, zRotation));
       tankDriveVelocity(wheelSpeeds.leftMetersPerSecond, wheelSpeeds.rightMetersPerSecond);
     } else {
-      differentialDrive.arcadeDrive(speed, rotation, useSquares);
+      leftMaster.set(FEED_FORWARD.calculate(wheelSpeeds.leftMetersPerSecond) / 12);
+      rightMaster.set(FEED_FORWARD.calculate(wheelSpeeds.rightMetersPerSecond) / 12);
     }
   }
 
@@ -213,16 +209,17 @@ public class DriveTrainSubsystem extends SubsystemBase {
    * @param useSquares if set, decreases input sensitivity at low speeds
    */
   public void tankDrive(double leftSpeed, double rightSpeed, boolean useSquares) {
+    var xLeftSpeed = safeClamp(leftSpeed) * MAX_SPEED_ARCADE;
+    var xRightSpeed = safeClamp(rightSpeed) * MAX_SPEED_ARCADE;
+    if (useSquares) {
+      xLeftSpeed *= Math.abs(xLeftSpeed);
+      xRightSpeed *= Math.abs(xRightSpeed);
+    }
     if(useEncoders) {
-      var xLeftSpeed = safeClamp(leftSpeed) * MAX_SPEED_ARCADE;
-      var xRightSpeed = safeClamp(rightSpeed) * MAX_SPEED_ARCADE;
-      if (useSquares) {
-        xLeftSpeed *= Math.abs(xLeftSpeed);
-        xRightSpeed *= Math.abs(xRightSpeed);
-      }
       tankDriveVelocity(xLeftSpeed, xRightSpeed);
     } else {
-      differentialDrive.tankDrive(leftSpeed, rightSpeed, useSquares);
+      leftMaster.set(FEED_FORWARD.calculate(xLeftSpeed) / 12);
+      rightMaster.set(FEED_FORWARD.calculate(xRightSpeed) / 12);
     }
   }
 
@@ -250,7 +247,6 @@ public class DriveTrainSubsystem extends SubsystemBase {
         metersPerSecToEdgesPerDecisec(rightVelocity),
         DemandType.ArbitraryFeedForward,
         rightFeedForwardVolts / 12);
-    differentialDrive.feed();
   }
 
   /**


### PR DESCRIPTION
This PR implements feedforward-only control when the encoders are not being used for closed-loop velocity mode.

This came up because `ShootCommand` sometime fails to spin to the target when the error is small. We need to add feedforward to overcome static friction (`kS`). An uncharacterized approach to this is either a nominal output, or a constant feedforward (`kF`) like we were trying to implement [here](https://github.com/STMARobotics/frc-7028-2020/blob/master/src/main/java/frc/robot/commands/ShootCommand.java#L76), but this should be more precise and consistent with our drive characteristics.

We don't know if this small error problem exists when `useEncoders` is true, but in theory it would already be solved. We'll have to try it and see once we know the encoders are working.

See this Chief Delphi post where oblarg pointed out how to do this:
https://www.chiefdelphi.com/t/turn-to-angle-example/377899/11?u=gdefender